### PR TITLE
Fix: Flicker on updates

### DIFF
--- a/games/common/border.cpp
+++ b/games/common/border.cpp
@@ -11,7 +11,7 @@ Border::Border(int rows, int cols, int start_y, int start_x)
 
 void Border::refresh() const
 {
-    werase(window);
+    // no `werase` since we don't want to erase the subwindow.
     box(window, 0, 0);  // create window border
     wnoutrefresh(window);
 }

--- a/games/common/border.cpp
+++ b/games/common/border.cpp
@@ -11,9 +11,9 @@ Border::Border(int rows, int cols, int start_y, int start_x)
 
 void Border::refresh() const
 {
-    wclear(window);
+    werase(window);
     box(window, 0, 0);  // create window border
-    wrefresh(window);
+    wnoutrefresh(window);
 }
 
 }  // namespace games

--- a/games/mines/app.cpp
+++ b/games/mines/app.cpp
@@ -28,7 +28,6 @@ void App::run()
 {
     while (true) {
         wmove(board.window, cursor_y, cursor_x);
-        // HACK: `wgetch` calls `doupdate`, which conveniently updates the terminal :)
         const int key = wgetch(board.window);
         if (!handle_keystroke(key)) {
             break;
@@ -45,6 +44,7 @@ void App::refresh() const
     board.refresh();
     text_end_game.refresh();
     text_instructions.refresh();
+    doupdate();
 }
 
 bool App::handle_keystroke(int key)

--- a/games/mines/app.cpp
+++ b/games/mines/app.cpp
@@ -12,7 +12,7 @@ App::App(int rows, int cols, int mines)
       cursor_x((cols - 1) / 2),
       text_mine_count(board, MARGIN_TOP, MARGIN_LEFT),
       board_border(rows, cols, text_mine_count.bottom(), MARGIN_LEFT),
-      board(rows, cols, mines, board_border.inner_start_y(), board_border.inner_start_x()),
+      board(rows, cols, mines, board_border.inner_start_y(), board_border.inner_start_x(), board_border.window),
       text_end_game(board, board_border.bottom(), MARGIN_LEFT),
       text_instructions(text_end_game.bottom(), MARGIN_LEFT)
 {
@@ -39,7 +39,9 @@ void App::run()
 void App::refresh() const
 {
     text_mine_count.refresh();
-    board_border.refresh();  // border must be updated before board
+    // if `board` were not a subwindow of `board_border`, we would have to
+    // always refresh `board_border` before `board` to avoid overwriting text.
+    board_border.refresh();
     board.refresh();
     text_end_game.refresh();
     text_instructions.refresh();

--- a/games/mines/app.cpp
+++ b/games/mines/app.cpp
@@ -28,6 +28,7 @@ void App::run()
 {
     while (true) {
         wmove(board.window, cursor_y, cursor_x);
+        // HACK: `wgetch` calls `doupdate`, which conveniently updates the terminal :)
         const int key = wgetch(board.window);
         if (!handle_keystroke(key)) {
             break;
@@ -102,24 +103,17 @@ bool App::handle_keystroke(int key)
             break;
         case 'f':  // flag
             if (board.toggle_flag(cursor_y, cursor_x) == 0) {
-                // only need to refresh mine count and board
-                text_mine_count.refresh();
-                board.refresh();
+                refresh();
             }
             break;
         case ' ':  // open
             if (board.click_cell(cursor_y, cursor_x) == 0) {
-                // only need to refresh board and end game text
-                board.refresh();
-                text_end_game.refresh();
+                refresh();
             }
             break;
         case 'z':  // new game
             board.reset();
-            // only need to refresh mine count, board, and end game text
-            text_mine_count.refresh();
-            board.refresh();
-            text_end_game.refresh();
+            refresh();
             break;
         case 'r':  // refresh
             refresh();

--- a/games/mines/app.cpp
+++ b/games/mines/app.cpp
@@ -39,7 +39,7 @@ void App::run()
 void App::refresh() const
 {
     text_mine_count.refresh();
-    board_border.refresh();
+    board_border.refresh();  // border must be updated before board
     board.refresh();
     text_end_game.refresh();
     text_instructions.refresh();

--- a/games/mines/board.cpp
+++ b/games/mines/board.cpp
@@ -8,8 +8,8 @@
 namespace games::mines
 {
 
-Board::Board(int rows, int cols, int mines, int start_y, int start_x)
-    : Component(newwin(rows, cols, start_y, start_x)),
+Board::Board(int rows, int cols, int mines, int start_y, int start_x, WINDOW* border_window)
+    : Component(subwin(border_window, rows, cols, start_y, start_x)),
       rows(rows),
       cols(cols),
       mines(mines),

--- a/games/mines/board.cpp
+++ b/games/mines/board.cpp
@@ -32,14 +32,14 @@ Board::Board(int rows, int cols, int mines, int start_y, int start_x)
 
 void Board::refresh() const
 {
-    wclear(window);
+    werase(window);
     for (int row = 0; row < rows; ++row) {
         wmove(window, row, 0);
         for (int col = 0; col < cols; ++col) {
             print_cell(row, col);
         }
     }
-    wrefresh(window);
+    wnoutrefresh(window);
 }
 
 void Board::print_cell(int row, int col) const

--- a/games/mines/board.hpp
+++ b/games/mines/board.hpp
@@ -28,8 +28,9 @@ public:
      * @param mines Number of mines.
      * @param start_y y-coordinate of the top-left corner of the window.
      * @param start_x x-coordinate of the top-left corner of the window.
+     * @param border_window Parent window containing border.
      */
-    Board(int rows, int cols, int mines, int start_y, int start_x);
+    Board(int rows, int cols, int mines, int start_y, int start_x, WINDOW* border_window);
 
     /**
      * Refresh the board viewed by the user.

--- a/games/mines/text_end_game.cpp
+++ b/games/mines/text_end_game.cpp
@@ -14,7 +14,7 @@ TextEndGame::TextEndGame(const Board& board, int start_y, int start_x)
 
 void TextEndGame::refresh() const
 {
-    wclear(window);
+    werase(window);
     switch (board.get_state()) {
         case BoardState::active:
             break;
@@ -33,7 +33,7 @@ void TextEndGame::refresh() const
             break;
         }
     }
-    wrefresh(window);
+    wnoutrefresh(window);
 }
 
 }  // namespace games::mines

--- a/games/mines/text_instructions.cpp
+++ b/games/mines/text_instructions.cpp
@@ -13,7 +13,7 @@ TextInstructions::TextInstructions(int start_y, int start_x)
 
 void TextInstructions::refresh() const
 {
-    wclear(window);
+    werase(window);
     const auto attr = COLOR_PAIR(COLOR_PAIR_INSTRUCTIONS);
     wattron(window, attr);
     mvwprintw(window, 0, 0, "move cursor     hjkl / arrow keys");
@@ -23,7 +23,7 @@ void TextInstructions::refresh() const
     mvwprintw(window, 4, 0, "new game        z");
     mvwprintw(window, 5, 0, "quit            q");
     wattroff(window, attr);
-    wrefresh(window);
+    wnoutrefresh(window);
 }
 
 }  // namespace games::mines

--- a/games/mines/text_mine_count.cpp
+++ b/games/mines/text_mine_count.cpp
@@ -12,9 +12,9 @@ TextMineCount::TextMineCount(const Board& board, int start_y, int start_x)
 
 void TextMineCount::refresh() const
 {
-    wclear(window);
+    werase(window);
     mvwprintw(window, 0, 0, "MINES: %-4d", board.mines - board.get_num_flags());
-    wrefresh(window);
+    wnoutrefresh(window);
 }
 
 }  // namespace games::mines

--- a/games/snakes/app.cpp
+++ b/games/snakes/app.cpp
@@ -48,7 +48,7 @@ void App::run()
             doupdate();
         }
 
-        // flushinp();  // clear input buffer to avoid keystrokes from building up
+        flushinp();  // clear input buffer to avoid keystrokes from building up
     }
 }
 

--- a/games/snakes/app.cpp
+++ b/games/snakes/app.cpp
@@ -45,9 +45,10 @@ void App::run()
         if (iframe % update_interval_frames == 0) {
             board.update();
             board.refresh();
+            doupdate();
         }
 
-        flushinp();  // clear input buffer to avoid keystrokes from building up
+        // flushinp();  // clear input buffer to avoid keystrokes from building up
     }
 }
 
@@ -55,6 +56,7 @@ void App::refresh() const
 {
     board_border.refresh();
     board.refresh();
+    doupdate();
 }
 
 bool App::handle_keystroke(int key)

--- a/games/snakes/board.cpp
+++ b/games/snakes/board.cpp
@@ -19,9 +19,9 @@ Board::Board(int rows, int cols, int start_y, int start_x)
 
 void Board::refresh() const
 {
-    wclear(window);
+    werase(window);
     snake.draw(window);
-    wrefresh(window);
+    wnoutrefresh(window);
 }
 
 void Board::update()


### PR DESCRIPTION
Depending on the terminal, the Minesweeper game screen flickered on every refresh. The root issues were (1) `wclear` causing full re-renders, and `wrefresh` being called on each window leading to inefficient rendering.

The fix for the first issue is to use `werase` instead.

The fix for the second is to replace `wrefresh` with `wnoutrefresh` (which updates virtual buffers) and calling `doupdate` only once (which updates the actual terminal).